### PR TITLE
Fix bug causing error when adding hotel without image.

### DIFF
--- a/django/pythonProject/BookHotel/booking/views.py
+++ b/django/pythonProject/BookHotel/booking/views.py
@@ -158,7 +158,15 @@ import os
 @csrf_exempt
 def get_hotels(request):
     hotels = Hotel.objects.all()
-    return JsonResponse({'image_urls': [hotel.image.path for hotel in hotels]})
+    print(hotels)
+    image_urls = []
+    for hotel in hotels:
+        try:
+            image_urls.append(hotel.image.path)
+        except Exception:
+            # Maybe, one Hotel has not any Image at all
+            continue
+    return JsonResponse({'image_urls': image_urls})
 
 
 @csrf_exempt


### PR DESCRIPTION
The bug that occurs when a hotel is added without an associated image. The previous implementation of the get_hotels function resulted in an internal server error when attempting to access the path attribute of a missing image file. This update includes a check to handle hotels without images gracefully, preventing the application from crashing.